### PR TITLE
fix: dynamic client-side max file size validation

### DIFF
--- a/internal/models/response.go
+++ b/internal/models/response.go
@@ -32,6 +32,7 @@ type WebPageData struct {
 	Title            string
 	Theme            string
 	FileExpiryHours  int
+	MaxFileSize      int64
 	MaxFileSizeHuman string
 	BaseURL          string
 	Filename         string

--- a/internal/services/template.go
+++ b/internal/services/template.go
@@ -121,6 +121,7 @@ func (s *TemplateService) RenderUploadPage(c *fiber.Ctx, baseURL string) error {
 		Title:            "Upload File",
 		Theme:            s.config.DefaultTheme,
 		FileExpiryHours:  s.config.FileExpiryHours,
+		MaxFileSize:      s.config.MaxFileSize,
 		MaxFileSizeHuman: s.formatBytes(s.config.MaxFileSize),
 		BaseURL:          baseURL,
 	}

--- a/web/static/js/app.js
+++ b/web/static/js/app.js
@@ -11,7 +11,12 @@ class TempFilesUI {
         this.fileInfo = document.querySelector('.file-info');
         this.alertContainer = document.querySelector('.alert');
         
-        this.maxFileSize = 100 * 1024 * 1024; // 100MB
+        // Read max file size from data attribute, fallback to 100MB
+        const uploadAreaEl = document.getElementById('uploadArea');
+        this.maxFileSize = uploadAreaEl?.dataset.maxFileSize 
+            ? parseInt(uploadAreaEl.dataset.maxFileSize, 10) 
+            : 100 * 1024 * 1024;
+        this.maxFileSizeHuman = uploadAreaEl?.dataset.maxFileSizeHuman || '100.0 MB';
         this.selectedFile = null;
         
         this.init();
@@ -209,7 +214,7 @@ class TempFilesUI {
         
         // Validate file size
         if (file.size > this.maxFileSize) {
-            this.showAlert('File size exceeds 100MB limit', 'error');
+            this.showAlert(`File size exceeds ${this.maxFileSizeHuman} limit`, 'error');
             return;
         }
         

--- a/web/templates/upload.html
+++ b/web/templates/upload.html
@@ -44,7 +44,7 @@
             <div class="card">
                 <form id="uploadForm" action="/" method="POST" enctype="multipart/form-data">
                     <!-- Upload Area -->
-                    <div class="upload-area" id="uploadArea">
+                    <div class="upload-area" id="uploadArea" data-max-file-size="{{.MaxFileSize}}" data-max-file-size-human="{{.MaxFileSizeHuman}}">
                         <div class="upload-icon">📁</div>
                         <div class="upload-text">Drop files here or click to browse</div>
                         <div class="upload-subtext">Maximum file size: {{.MaxFileSizeHuman}}</div>


### PR DESCRIPTION
## Summary
Fix client-side JavaScript validation to use configured `MAX_FILE_SIZE` instead of hardcoded 100MB.

## Problem
After PR #5, the template displays correct max file size, but JavaScript validation still uses hardcoded 100MB, causing incorrect error messages.

## Solution
- Add `MaxFileSize` (int64) to WebPageData struct
- Pass raw bytes value to template via data attributes
- JavaScript reads from `data-max-file-size` attribute
- Error message now shows configured limit

## Changes
| File | Change |
|------|--------|
| `internal/models/response.go` | Add MaxFileSize field |
| `internal/services/template.go` | Pass MaxFileSize to template |
| `web/templates/upload.html` | Add data attributes |
| `web/static/js/app.js` | Read from data attributes |

## Before
```
File size exceeds 100MB limit  (always 100MB)
```

## After
```
File size exceeds 200.0 MB limit  (from config)
```

---
*Created by: Sarah (Assistant)*